### PR TITLE
Update mlflow Version

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8.0
 
 RUN pip install \
-    mlflow==1.23.1 \
+    mlflow==1.26.1 \
     pymysql==1.0.2 \
     boto3 && \
     mkdir /mlflow/


### PR DESCRIPTION
Current version affected by https://github.com/mlflow/mlflow/issues/5949 --mlflow won't start due to this if deployed as is

*Issue #, if available:*

Issue #6 

*Description of changes:*
Update mlflow version to fix https://github.com/mlflow/mlflow/issues/5949

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
