### PR TITLE
Pin protobuf version to 3.20.0

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.8.0
 
 RUN pip install \
     mlflow==1.23.1 \
+    protobuf==3.20.0 \
     pymysql==1.0.2 \
     boto3 && \
     mkdir /mlflow/


### PR DESCRIPTION
Pins the protobuf version as a workaround to this issue: https://github.com/mlflow/mlflow/issues/5949

*Issue #, if available:*
#6

*Description of changes:*

Pin protobuf version to 3.20.0 to workaround this issue: https://github.com/mlflow/mlflow/issues/5949

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
