### PR TITLE
Set ARM64 for CPU architecture.

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from aws_cdk import (
     Aws,
     RemovalPolicy,
     Duration,
+    DefaultStackSynthesizer,
 )
 from constructs import Construct
 
@@ -144,6 +145,10 @@ class MLflowStack(Stack):
             task_role=role,
             cpu=4 * 1024,
             memory_limit_mib=8 * 1024,
+            runtime_platform=ecs.RuntimePlatform(
+                operating_system_family=ecs.OperatingSystemFamily.LINUX,
+                cpu_architecture=ecs.CpuArchitecture.ARM64
+            ),
         )
 
         container = task_definition.add_container(

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3.10.12
+FROM --platform=linux/amd64 python:3.10.12
+
+RUN pip install -U pip
 
 RUN pip install \
-    mlflow==2.6.0 \
+    mlflow>=2.7.1 \
     pymysql==1.0.2 \
     boto3 && \
     mkdir /mlflow/


### PR DESCRIPTION
*Description of changes:*

When performing `cdk deploy` from the M1 mac environment, there was a problem that Fargate could not be executed due to a CPU architecture issue.
Therefore, I explicitly set the CPU architecture used in Docker's multi-platform images and Fargate task to ARM64 so that MLFlow can be started without any problems.